### PR TITLE
fixed 'trim' of null error

### DIFF
--- a/lib/jquery.markdownify.js
+++ b/lib/jquery.markdownify.js
@@ -43,9 +43,9 @@
           }
         },
         video : function () {
-          var videoLink = window.prompt('Enter a video url ex: https://www.youtube.com/watch?v=bGutVrdL3M8').trim();
+          var videoLink = window.prompt('Enter a video url ex: https://www.youtube.com/watch?v=bGutVrdL3M8');
           if (videoLink && videoLink.length > 0){
-            editor.replaceSelection("\n" + videoLink + "\n\n")
+            editor.replaceSelection("\n" + $.trim(videoLink)+ "\n\n")
           }
         },
         img : function (e) {


### PR DESCRIPTION
To recreate the console error, 
1. click on video link
2. In the window prompt click cancel 

jquery.markdownify.js:46 Uncaught TypeError: Cannot read property 'trim' of null

this fixes it by passing the prompt response into $.trim()
