### PR TITLE
toggle 'markdownify-menu' buttons visibility

### DIFF
--- a/lib/jquery.markdownify.js
+++ b/lib/jquery.markdownify.js
@@ -64,6 +64,7 @@
         var $this = $(this);
 
         $(editor.getWrapperElement()).toggleClass('markdownify--hidden');
+        $('.markdownify-menu[data-target="' + current_element.id + '"]').toggleClass('markdownify--hidden');
         $('.' + $this.data('target') + '-preview').toggleClass('markdownify--hidden').html(marked(($('#' + $this.data('target'))).html()));
 
         // When the input text is the same as the default, we use the opposite text (clicked v default)


### PR DESCRIPTION
When in preview mode, hide 'markdownify-menu' buttons.