### PR TITLE
Correct wrong CDN

### DIFF
--- a/demo/simple-with-buttons.html
+++ b/demo/simple-with-buttons.html
@@ -4,12 +4,12 @@
     <title>Markdownify</title>
     <meta charset="utf-8"/>
     <script src="https://cdn.rawgit.com/tibastral/markdownify/master/vendor/jquery.min.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/lib/codemirror.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/addon/edit/continuelist.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/mode/xml/xml.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/mode/markdown/markdown.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/addon/edit/continuelist.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/xml/xml.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/markdown/markdown.js"></script>
     <script src='https://cdn.rawgit.com/chjj/marked/master/lib/marked.js' type='text/javascript'></script>
-    <link rel='stylesheet' href="https://cdn.rawgit.com/marijnh/CodeMirror/master/lib/codemirror.css"></link>
+    <link rel='stylesheet' href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.css"></link>
 
     <script src="../lib/jquery.markdownify.js"></script>
     <link rel="stylesheet" href="../lib/jquery.markdownify.css"></link>

--- a/demo/simple-with-image-upload.html
+++ b/demo/simple-with-image-upload.html
@@ -4,16 +4,16 @@
     <title>Markdownify</title>
     <meta charset="utf-8"/>
     <script src="https://cdn.rawgit.com/tibastral/markdownify/master/vendor/jquery.min.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/lib/codemirror.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/addon/edit/continuelist.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/mode/xml/xml.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/mode/markdown/markdown.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/addon/edit/continuelist.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/xml/xml.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/markdown/markdown.js"></script>
     <script src='https://cdn.rawgit.com/chjj/marked/master/lib/marked.js' type='text/javascript'></script>
     <script src='https://cdn.rawgit.com/cloudinary/cloudinary_js/master/js/jquery.ui.widget.js' type='text/javascript'></script>
     <script src='https://cdn.rawgit.com/cloudinary/cloudinary_js/master/js/jquery.iframe-transport.js' type='text/javascript'></script>
     <script src='https://cdn.rawgit.com/cloudinary/cloudinary_js/master/js/jquery.fileupload.js' type='text/javascript'></script>
     <script src='https://cdn.rawgit.com/cloudinary/cloudinary_js/master/js/jquery.cloudinary.js' type='text/javascript'></script>
-    <link rel='stylesheet' href="https://cdn.rawgit.com/marijnh/CodeMirror/master/lib/codemirror.css"></link>
+    <link rel='stylesheet' href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.css"></link>
 
     <script src="../lib/jquery.markdownify.js"></script>
     <link rel="stylesheet" href="../lib/jquery.markdownify.css"></link>

--- a/demo/simple.html
+++ b/demo/simple.html
@@ -4,12 +4,12 @@
     <title>Markdownify</title>
     <meta charset="utf-8"/>
     <script src="https://cdn.rawgit.com/tibastral/markdownify/master/vendor/jquery.min.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/lib/codemirror.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/addon/edit/continuelist.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/addon/edit/continuelist.js"></script>
     <script src='https://cdn.rawgit.com/chjj/marked/master/lib/marked.js' type='text/javascript'></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/mode/xml/xml.js"></script>
-    <script src="https://cdn.rawgit.com/marijnh/CodeMirror/master/mode/markdown/markdown.js"></script>
-    <link rel='stylesheet' href="https://cdn.rawgit.com/marijnh/CodeMirror/master/lib/codemirror.css"></link>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/xml/xml.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/mode/markdown/markdown.js"></script>
+    <link rel='stylesheet' href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.25.2/codemirror.css"></link>
 
     <script src="../lib/jquery.markdownify.js"></script>
     <link rel="stylesheet" href="../lib/jquery.markdownify.css"></link>


### PR DESCRIPTION
The repo for CodeMirror is subject to potential changes, and codemirror.js disappeared. This PR fix it, by using a CDN for every CodeMirror stuff needed by markdownify.